### PR TITLE
fix action name for public ajax request

### DIFF
--- a/includes/newsletter-integration/Mailchimp.php
+++ b/includes/newsletter-integration/Mailchimp.php
@@ -74,7 +74,7 @@ if( ! class_exists( 'YITH_Popup_Newsletter_Mailchimp' ) ){
         public function add_form_handling(){
             // add mailchimp subscription
             add_action( 'wp_ajax_ypop_subscribe_mailchimp_user', array( $this, 'subscribe_mailchimp_user' ) );
-            add_action( 'wp_ajax_ypop_nopriv_subscribe_mailchimp_user', array( $this, 'subscribe_mailchimp_user'));
+            add_action( 'wp_ajax_nopriv_ypop_subscribe_mailchimp_user', array( $this, 'subscribe_mailchimp_user'));
         }
 
         /**


### PR DESCRIPTION
The popup returns 0 instead of a complete response for non logged in users.
see http://codex.wordpress.org/AJAX_in_Plugins#Ajax_on_the_Viewer-Facing_Side
